### PR TITLE
[P1 tests] [Team 11] Add WordBreak Tokenizer Tests

### DIFF
--- a/src/test/java/edu/uci/ics/cs221/analysis/wordbreak/Team11WordBreakTokenizerTest.java
+++ b/src/test/java/edu/uci/ics/cs221/analysis/wordbreak/Team11WordBreakTokenizerTest.java
@@ -41,15 +41,14 @@ public class Team11WordBreakTokenizerTest {
         assert(false);
     }
 
-    // Test with a normal case: it can be tokenized
+    // Test with a normal case: it can be tokenized with the highest probability
     @Test
     public void test4() {
         String text = "searchnewtimeuse";
         List<String> expected = Arrays.asList("search", "new", "time", "use");
         WordBreakTokenizer tokenizer = new WordBreakTokenizer();
-        tokenizer.tokenize(text);
-        // An exception should be thrown above, and the program should never reach the next line
-        assert(false);
+        
+        assertEquals(expected, tokenizer.tokenize(text));
     }
 
     // Test with a few upper cases
@@ -58,9 +57,8 @@ public class Team11WordBreakTokenizerTest {
         String text = "seaRchneWtiMeuSe";
         List<String> expected = Arrays.asList("search", "new", "time", "use");
         WordBreakTokenizer tokenizer = new WordBreakTokenizer();
-        tokenizer.tokenize(text);
-        // An exception should be thrown above, and the program should never reach the next line
-        assert(false);
+        
+        assertEquals(expected, tokenizer.tokenize(text));
     }
 
     // Test with all upper cases
@@ -69,9 +67,8 @@ public class Team11WordBreakTokenizerTest {
         String text = "SEARCHNEWTIMEUSE";
         List<String> expected = Arrays.asList("search", "new", "time", "use");
         WordBreakTokenizer tokenizer = new WordBreakTokenizer();
-        tokenizer.tokenize(text);
-        // An exception should be thrown above, and the program should never reach the next line
-        assert(false);
+        
+        assertEquals(expected, tokenizer.tokenize(text));
     }
 
     // Test with stop word at the beginning
@@ -80,9 +77,8 @@ public class Team11WordBreakTokenizerTest {
         String text = "thesearchnewtimeuse";
         List<String> expected = Arrays.asList("search", "new", "time", "use");
         WordBreakTokenizer tokenizer = new WordBreakTokenizer();
-        tokenizer.tokenize(text);
-        // An exception should be thrown above, and the program should never reach the next line
-        assert(false);
+        
+        assertEquals(expected, tokenizer.tokenize(text));
     }
 
     // Test with stop word in the middle
@@ -91,9 +87,8 @@ public class Team11WordBreakTokenizerTest {
         String text = "searchthenewtimeuse";
         List<String> expected = Arrays.asList("search", "new", "time", "use");
         WordBreakTokenizer tokenizer = new WordBreakTokenizer();
-        tokenizer.tokenize(text);
-        // An exception should be thrown above, and the program should never reach the next line
-        assert(false);
+        
+        assertEquals(expected, tokenizer.tokenize(text));
     }
 
     // Test with stop word in the end
@@ -102,8 +97,7 @@ public class Team11WordBreakTokenizerTest {
         String text = "searchnewtimeusethe";
         List<String> expected = Arrays.asList("search", "new", "time", "use");
         WordBreakTokenizer tokenizer = new WordBreakTokenizer();
-        tokenizer.tokenize(text);
-        // An exception should be thrown above, and the program should never reach the next line
-        assert(false);
+        
+        assertEquals(expected, tokenizer.tokenize(text));
     }
 }

--- a/src/test/java/edu/uci/ics/cs221/analysis/wordbreak/Team11WordBreakTokenizerTest.java
+++ b/src/test/java/edu/uci/ics/cs221/analysis/wordbreak/Team11WordBreakTokenizerTest.java
@@ -1,0 +1,109 @@
+package edu.uci.ics.cs221.analysis.wordbreak;
+
+import edu.uci.ics.cs221.analysis.WordBreakTokenizer;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class Team11WordBreakTokenizerTest {
+
+    // Test with a sentence that is only made up of stop words
+    @Test
+    public void test1() {
+        String text = "tobeornottobe";
+        List<String> expected = Arrays.asList();
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+
+        assertEquals(expected, tokenizer.tokenize(text));
+    }
+
+    // Empty input test
+    @Test
+    public void test2() {
+        String text = "";
+        List<String> expected = Arrays.asList();
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+
+        assertEquals(expected, tokenizer.tokenize(text));
+    }
+
+    // Input string cannot be tokenized, an UnsupportedOperationException is expected
+    @Test(expected = UnsupportedOperationException.class)
+    public void test3() {
+        String text = "b";
+        List<String> expected = Arrays.asList();
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+
+    // Test with a normal case: it can be tokenized
+    @Test
+    public void test4() {
+        String text = "searchnewtimeuse";
+        List<String> expected = Arrays.asList("search", "new", "time", "use");
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+
+    // Test with a few upper cases
+    @Test
+    public void test5() {
+        String text = "seaRchneWtiMeuSe";
+        List<String> expected = Arrays.asList("search", "new", "time", "use");
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+
+    // Test with all upper cases
+    @Test
+    public void test6() {
+        String text = "SEARCHNEWTIMEUSE";
+        List<String> expected = Arrays.asList("search", "new", "time", "use");
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+
+    // Test with stop word at the beginning
+    @Test
+    public void test7() {
+        String text = "thesearchnewtimeuse";
+        List<String> expected = Arrays.asList("search", "new", "time", "use");
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+
+    // Test with stop word in the middle
+    @Test
+    public void test8() {
+        String text = "searchthenewtimeuse";
+        List<String> expected = Arrays.asList("search", "new", "time", "use");
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+
+    // Test with stop word in the end
+    @Test
+    public void test9() {
+        String text = "searchnewtimeusethe";
+        List<String> expected = Arrays.asList("search", "new", "time", "use");
+        WordBreakTokenizer tokenizer = new WordBreakTokenizer();
+        tokenizer.tokenize(text);
+        // An exception should be thrown above, and the program should never reach the next line
+        assert(false);
+    }
+}


### PR DESCRIPTION
What's your team number?
Team 11

What is the functionality being tested?
Wordbreak Tokenizer

Describe your tests briefly:
Test 1: Test with a sentence that is only made up of stop words
Test 2: Empty input test
Test 3: Input string cannot be tokenized, an UnsupportedOperationException is expected
Test 4: Test with a normal case: it can be tokenized
Test 5: Test with a few upper cases
Test 6: Test with all upper cases
Test 7: Test with stop word at the beginning
Test 8: Test with stop word in the middle
Test 9: Testwith stop word in the end

Does each test case have comments/documentation?
Yes