### PR TITLE
[P2 tests] [Team 18] Add Task 1 Flush Tests

### DIFF
--- a/src/test/java/index/inverted/Team18FlushTest.java
+++ b/src/test/java/index/inverted/Team18FlushTest.java
@@ -53,7 +53,7 @@ public class Team18FlushTest {
         Collections.sort(invertedList);
         assertEquals(expectedInvertedList, invertedList);
 
-        clear();
+        
 
     }
 
@@ -73,7 +73,7 @@ public class Team18FlushTest {
         assertEquals(0, invertedLists.size());
         assertEquals(0, documents.size());
 
-        clear();
+
     }
 
 
@@ -107,9 +107,10 @@ public class Team18FlushTest {
             assertEquals(doc1, documents.get(i));
         }
 
-        clear();
+
     }
 
+    @After
     public void clear(){
         File dir = new File("./index/Team18FlushTest");
         for (File file: dir.listFiles()){

--- a/src/test/java/index/inverted/Team18FlushTest.java
+++ b/src/test/java/index/inverted/Team18FlushTest.java
@@ -64,16 +64,7 @@ public class Team18FlushTest {
     @Test
     public void test2(){
         manager.flush();
-        int expectedNumSegments = 0;
-        assertEquals(expectedNumSegments, manager.getNumSegments());
-
-        InvertedIndexSegmentForTest iiTestSegment = manager.getIndexSegment(0);
-        Map<String, List<Integer>> invertedLists = iiTestSegment.getInvertedLists();
-        Map<Integer, Document> documents = iiTestSegment.getDocuments();
-        assertEquals(0, invertedLists.size());
-        assertEquals(0, documents.size());
-
-
+        assertEquals(null, manager.getIndexSegment(0));
     }
 
 

--- a/src/test/java/index/inverted/Team18FlushTest.java
+++ b/src/test/java/index/inverted/Team18FlushTest.java
@@ -1,0 +1,124 @@
+package index.inverted;
+
+import edu.uci.ics.cs221.analysis.*;
+import edu.uci.ics.cs221.index.inverted.InvertedIndexManager;
+import edu.uci.ics.cs221.index.inverted.InvertedIndexSegmentForTest;
+import edu.uci.ics.cs221.storage.Document;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class Team18FlushTest {
+    public InvertedIndexManager manager;
+    String folderPath = "./index/Team18FlushTest";
+
+    @Before
+    public void initialize(){
+        manager = InvertedIndexManager.createOrOpen(folderPath, new ComposableAnalyzer(new PunctuationTokenizer(), new PorterStemmer()));
+    }
+
+
+    Document doc1 = new Document("kitten, bunny");
+    Document doc2 = new Document("bunny");
+    PorterStemmer ps = new PorterStemmer();
+    // test flush() when called and numSegments less than DEFAULT_FLUSH_THRESHOLD
+    @Test
+    public void test1(){
+        manager.addDocument(doc1);
+        manager.addDocument(doc2);
+        manager.flush();
+        int expectedNumSegments = 1;
+        assertEquals(expectedNumSegments, manager.getNumSegments());
+
+        InvertedIndexSegmentForTest iiTestSegment = manager.getIndexSegment(0);
+        Map<String, List<Integer>> invertedLists = iiTestSegment.getInvertedLists();
+        Map<Integer, Document> documents = iiTestSegment.getDocuments();
+        assertEquals(2, invertedLists.size());
+        assertEquals(2, documents.size());
+        assertEquals(doc1, documents.get(0));
+        assertEquals(doc2, documents.get(1));
+
+
+        List<Integer> invertedList = invertedLists.get(ps.stem("kitten"));
+        List<Integer> expectedInvertedList = Arrays.asList(0);
+        assertEquals(expectedInvertedList, invertedList);
+        invertedList = invertedLists.get(ps.stem("bunny"));
+        expectedInvertedList = Arrays.asList(0, 1);
+        Collections.sort(invertedList);
+        assertEquals(expectedInvertedList, invertedList);
+
+        clear();
+
+    }
+
+
+
+
+    // test flush() has no operation when no document is added
+    @Test
+    public void test2(){
+        manager.flush();
+        int expectedNumSegments = 0;
+        assertEquals(expectedNumSegments, manager.getNumSegments());
+
+        InvertedIndexSegmentForTest iiTestSegment = manager.getIndexSegment(0);
+        Map<String, List<Integer>> invertedLists = iiTestSegment.getInvertedLists();
+        Map<Integer, Document> documents = iiTestSegment.getDocuments();
+        assertEquals(0, invertedLists.size());
+        assertEquals(0, documents.size());
+
+        clear();
+    }
+
+
+
+
+    // test flush() when DEFAULT_FLUSH_THRESHOLD documents is added
+    @Test
+    public void test3(){
+        for(int i = 0; i < InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD; i ++)
+            manager.addDocument(doc1);
+        manager.addDocument(doc2);
+        manager.flush();
+
+        assertEquals(2, manager.getNumSegments());
+
+        InvertedIndexSegmentForTest iiTestSegment = manager.getIndexSegment(0);
+        Map<String, List<Integer>> invertedLists = iiTestSegment.getInvertedLists();
+        Map<Integer, Document> documents = iiTestSegment.getDocuments();
+
+        assertEquals(2, invertedLists.size());
+        List<Integer> invertedList_1 = invertedLists.get(ps.stem("kitten"));
+        List<Integer> invertedList_2 = invertedLists.get(ps.stem("bunny"));
+        Collections.sort(invertedList_1);
+        Collections.sort(invertedList_2);
+
+        assertEquals(1000, documents.size());
+
+        for(int i = 0; i < 1000; i ++){
+            assertEquals(i, invertedList_1.get(i).intValue());
+            assertEquals(i, invertedList_2.get(i).intValue());
+            assertEquals(doc1, documents.get(i));
+        }
+
+        clear();
+    }
+
+    public void clear(){
+        File dir = new File("./index/Team18FlushTest");
+        for (File file: dir.listFiles()){
+            if (!file.isDirectory()){
+                file.delete();
+            }
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
What's your team number?
Team 18

What is the functionality being tested?
Task 1: Flush and Read Segments (no merge)

Describe your tests briefly:
test1 tests given flush() called and document number not exceeding flush threshold, getNumSegment() and getDocuments() function or not.
test2 tests given no document added and flush() called getNumSegment() and getDocuments() function or not.
test3 tests given number of documents exceeding flush threshold, flush() is called automatically and getNumSegment() and getDocuments() function or not.
clear() use Junit @After to delete all written files after each test.

Does each test case have comments/documentation?
Yes