### PR TITLE
[P3 tests] Update P3 test cases

### DIFF
--- a/src/test/java/edu/uci/ics/cs221/index/positional/Team11PhraseSearchTest.java
+++ b/src/test/java/edu/uci/ics/cs221/index/positional/Team11PhraseSearchTest.java
@@ -9,15 +9,14 @@ import edu.uci.ics.cs221.index.inverted.Compressor;
 import edu.uci.ics.cs221.index.inverted.DeltaVarLenCompressor;
 import edu.uci.ics.cs221.storage.Document;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 
 public class Team11PhraseSearchTest {
@@ -75,10 +74,15 @@ public class Team11PhraseSearchTest {
     public void PhraseSearchTest1(){
         InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD = 1;
         index.addDocument(documents[0]);
+
+        Set<Document> expected = new HashSet<>(Arrays.asList(documents[0]));
+        Set<Document> actual = new HashSet<>();
+
         Iterator<Document> itr = index.searchPhraseQuery(Arrays.asList("eat", "beforehand"));
         while (itr.hasNext()){
-            assertEquals(itr.next(), documents[0]);
+            actual.add(itr.next());
         }
+        Assert.assertEquals(expected, actual);
     }
 
     /*
@@ -91,12 +95,15 @@ public class Team11PhraseSearchTest {
         for (Document doc : documents){
             index.addDocument(doc);
         }
-        int i = 0;
-        List<Document> expectedDocuments = Arrays.asList(documents[1], documents[3]);
+
+        Set<Document> expected = new HashSet<>(Arrays.asList(documents[1], documents[3]));
+        Set<Document> actual = new HashSet<>();
+
         Iterator<Document> itr = index.searchPhraseQuery(Arrays.asList("Summer", "Pizza", "House"));
         while (itr.hasNext()){
-            assertEquals(itr.next(), expectedDocuments.get(i++));
+            actual.add(itr.next());
         }
+        Assert.assertEquals(expected, actual);
     }
 
     /*
@@ -109,12 +116,15 @@ public class Team11PhraseSearchTest {
         for (Document doc : documents){
             index.addDocument(doc);
         }
-        int i = 0;
-        List<Document> expectedDocuments = Arrays.asList(documents[0], documents[2], documents[6]);
+
+        Set<Document> expected = new HashSet<>(Arrays.asList(documents[0], documents[2], documents[6]));
+        Set<Document> actual = new HashSet<>();
+
         Iterator<Document> itr = index.searchPhraseQuery(Arrays.asList("good", "idea"));
         while (itr.hasNext()){
-            assertEquals(itr.next(), expectedDocuments.get(i++));
+            actual.add(itr.next());
         }
+        Assert.assertEquals(expected, actual);
     }
 
     /*

--- a/src/test/java/edu/uci/ics/cs221/index/positional/Team17PhraseSearchTest.java
+++ b/src/test/java/edu/uci/ics/cs221/index/positional/Team17PhraseSearchTest.java
@@ -100,7 +100,7 @@ public class Team17PhraseSearchTest {
         InvertedIndexManager iim;
         iim = InvertedIndexManager.createOrOpenPositional(path, new ComposableAnalyzer( new PunctuationTokenizer(), new PorterStemmer()), new NaiveCompressor());
         iim.addDocument(doc2);
-        for(int i=0; i<InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD*4; i++){
+        for(int i=0; i<InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD*4 - 1; i++){
             iim.addDocument(doc1);
         }
         iim.mergeAllSegments();
@@ -127,7 +127,7 @@ public class Team17PhraseSearchTest {
         InvertedIndexManager iim;
         iim = InvertedIndexManager.createOrOpenPositional(path, new ComposableAnalyzer( new PunctuationTokenizer(), new PorterStemmer()), new NaiveCompressor());
         iim.addDocument(doc2);
-        for(int i=0; i<InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD*4; i++){
+        for(int i=0; i<InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD*4 - 1; i++){
             iim.addDocument(doc1);
         }
         iim.mergeAllSegments();

--- a/src/test/java/edu/uci/ics/cs221/index/positional/Team17PhraseSearchTest.java
+++ b/src/test/java/edu/uci/ics/cs221/index/positional/Team17PhraseSearchTest.java
@@ -70,7 +70,7 @@ public class Team17PhraseSearchTest {
     public void testPopularPhrases(){
         InvertedIndexManager iim;
         iim = InvertedIndexManager.createOrOpenPositional(path, new ComposableAnalyzer( new PunctuationTokenizer(), new PorterStemmer()), new NaiveCompressor());
-        for(int i=0; i<InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD+1; i++){
+        for(int i=0; i<InvertedIndexManager.DEFAULT_FLUSH_THRESHOLD; i++){
             iim.addDocument(doc3);
             iim.addDocument(doc4);
         }

--- a/src/test/java/edu/uci/ics/cs221/index/positional/Team5IndexCompressionTest.java
+++ b/src/test/java/edu/uci/ics/cs221/index/positional/Team5IndexCompressionTest.java
@@ -73,7 +73,6 @@ public class Team5IndexCompressionTest {
     int compress_rc = PageFileChannel.readCounter;
 
     System.out.println();
-    Assert.assertTrue(naive_rc > 1.5 * compress_rc);
     Assert.assertTrue(naive_wc > 1.5 * compress_wc);
     System.out.println("\033[0;32m");
     System.out.println("Naive compress write: " + naive_wc + " pages");
@@ -120,7 +119,6 @@ public class Team5IndexCompressionTest {
     int compress_wc = PageFileChannel.writeCounter;
     int compress_rc = PageFileChannel.readCounter;
 
-    Assert.assertTrue(naive_rc > 1.5 * compress_rc);
     Assert.assertTrue(naive_wc > 1.5 * compress_wc);
 
     System.out.println("\033[0;32m");
@@ -191,12 +189,6 @@ public class Team5IndexCompressionTest {
             + " delta write count: "
             + compress_wc,
         naive_wc > 1.5 * compress_wc);
-    Assert.assertTrue(
-        "naive write counter > 1.5 delta compress read count, \n Actual naive write: "
-            + naive_rc
-            + " delta write count: "
-            + compress_rc,
-        naive_rc > 1.5 * compress_rc);
 
     System.out.println("\033[0;32m");
     System.out.println("Naive compress write: " + naive_wc + " pages");
@@ -251,7 +243,6 @@ public class Team5IndexCompressionTest {
     int compress_wc = PageFileChannel.writeCounter;
     int compress_rc = PageFileChannel.readCounter;
 
-    Assert.assertTrue(naive_rc > 1.5 * compress_rc);
     Assert.assertTrue(naive_wc > 1.5 * compress_wc);
     System.out.println("\033[0;32m");
     System.out.println("Naive compress write: " + naive_wc + " pages");

--- a/src/test/java/edu/uci/ics/cs221/index/positional/Team6IndexCompressionTest.java
+++ b/src/test/java/edu/uci/ics/cs221/index/positional/Team6IndexCompressionTest.java
@@ -103,8 +103,6 @@ public class Team6IndexCompressionTest {
         compressReadCounter = PageFileChannel.readCounter;
         PageFileChannel.resetCounters();
 
-        assertEquals(true, compressReadCounter/nonCompressReadCounter < (double)2/3);
-
         assertEquals(true, compressWriteCounter/nonCompressWriteCounter < (double)2/3);
 
 


### PR DESCRIPTION
This PR contains changes to project 3 test cases.:

1. `Team5IndexCompressionTest` and `Team6IndexCompressionTest` are changed to only check write counter values. Read counter value checks are removed.
1. `Team17PhraseSearchTest` is changed to flush all documents before search.
1. `Team11PhraseSearchTest` is changed to compare search results in a set.
