### PR TITLE
[P4] Task 1 API change and add Task 2 API

### DIFF
--- a/src/main/java/edu/uci/ics/cs221/index/inverted/InvertedIndexManager.java
+++ b/src/main/java/edu/uci/ics/cs221/index/inverted/InvertedIndexManager.java
@@ -152,16 +152,20 @@ public class InvertedIndexManager {
 
     /**
      * Performs top-K ranked search using TF-IDF.
-     * Returns an iterator that returns the K documents with highest TF-IDF scores.
+     * Returns an iterator that returns the top K documents with highest TF-IDF scores.
+     *
+     * Each element is a pair of <Document, Double (TF-IDF Score)>.
+     *
+     * If parameter `topK` is null, then returns all the matching documents.
      *
      * Unlike Boolean Query and Phrase Query where order of the documents doesn't matter,
      * for ranked search, order of the document returned by the iterator matters.
      *
      * @param keywords, a list of keywords in the query
-     * @param topK, number of top documents weighted by TF-IDF
-     * @return a iterator of ordered documents matching the query
+     * @param topK, number of top documents weighted by TF-IDF, all documents if topK is null
+     * @return a iterator of top-k ordered documents matching the query
      */
-    public Iterator<Document> searchTfIdf(List<String> keywords, int topK) {
+    public Iterator<Pair<Document, Double>> searchTfIdf(List<String> keywords, Integer topK) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/edu/uci/ics/cs221/index/inverted/Pair.java
+++ b/src/main/java/edu/uci/ics/cs221/index/inverted/Pair.java
@@ -1,0 +1,48 @@
+package edu.uci.ics.cs221.index.inverted;
+
+import java.util.Objects;
+
+public class Pair<L, R> {
+
+    private final L left;
+    private final R right;
+
+    public Pair<L, R> of(L left, R right) {
+        return new Pair<>(left, right);
+    }
+
+    public Pair(L left, R right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public L getLeft() {
+        return left;
+    }
+
+    public R getRight() {
+        return right;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Pair<?, ?> pair = (Pair<?, ?>) o;
+        return Objects.equals(left, pair.left) &&
+                Objects.equals(right, pair.right);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right);
+    }
+
+    @Override
+    public String toString() {
+        return "Pair{" +
+                "left=" + left +
+                ", right=" + right +
+                '}';
+    }
+}

--- a/src/main/java/edu/uci/ics/cs221/search/IcsSearchEngine.java
+++ b/src/main/java/edu/uci/ics/cs221/search/IcsSearchEngine.java
@@ -1,0 +1,66 @@
+package edu.uci.ics.cs221.search;
+
+import edu.uci.ics.cs221.index.inverted.InvertedIndexManager;
+import edu.uci.ics.cs221.index.inverted.Pair;
+import edu.uci.ics.cs221.storage.Document;
+
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+
+public class IcsSearchEngine {
+
+    /**
+     * Initializes an IcsSearchEngine from the directory containing the documents and the
+     *
+     */
+    public static IcsSearchEngine createSearchEngine(Path documentDirectory, InvertedIndexManager indexManager) {
+        return new IcsSearchEngine(documentDirectory, indexManager);
+    }
+
+    private IcsSearchEngine(Path documentDirectory, InvertedIndexManager indexManager) {
+    }
+
+    /**
+     * Writes all ICS web page documents in the document directory to the inverted index.
+     */
+    public void writeIndex() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Computes the page rank score from the "id-graph.tsv" file in the document directory.
+     * The results of the computation can be saved in a class variable and will be later retrieved by `getPageRankScores`.
+     */
+    public void computePageRank() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Gets the page rank score of all documents previously computed. Must be called after `cmoputePageRank`.
+     * Returns an list of <DocumentID - Score> Pairs that is sorted by score in descending order (high scores first).
+     */
+    public List<Pair<Integer, Double>> getPageRankScores() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Searches the ICS document corpus and returns the top K documents ranked by combining TF-IDF and PageRank.
+     *
+     * The search process should first retrieve ALL the top documents from the InvertedIndex by TF-IDF rank,
+     * by calling `searchTfIdf(query, null)`.
+     *
+     * Then the corresponding PageRank score of each document should be retrieved. (`computePageRank` will be called beforehand)
+     * For each document, the combined score is  tfIdfScore + pageRankWeight * pageRankScore.
+     *
+     * Finally, the top K documents of the combined score are returned. Each element is a pair of <Document, combinedScore>
+     *
+     *
+     * Note: We could get the Document ID by reading the first line of the document.
+     * This is a workaround because our project doesn't support multiple fields. We cannot keep the documentID in a separate column.
+     */
+    public Iterator<Pair<Document, Double>> searchQuery(List<String> query, int topK, double pageRankWeight) {
+        throw new UnsupportedOperationException();
+    }
+
+}


### PR DESCRIPTION
As mentioned in class, we will have a change in Task 1 API `searchTfIdf`. 
The deadline of test cases and reviews are extended by two days. 
The new deadlines are 
 - Test Cases Due: Week 9 Th. (May 30). 
 - Review Due: Week 9 Sun (June 2)

Q: How will the change in Task 1 API affect the test cases?
A: The new API for `searchTfIdf` returns a pair of Document and its TF-IDF score. In your test cases, you don't need to check the score.  You only need to test the order of documents as before.